### PR TITLE
Added option to ignore URL colon variables

### DIFF
--- a/lib/weary/client.rb
+++ b/lib/weary/client.rb
@@ -77,8 +77,9 @@ module Weary
       # host - An optional String to set the client domain.
       #
       # Returns the domain String.
-      def domain(host=nil)
+      def domain(host=nil, options={})
         @domain = host unless host.nil?
+        @ignore_url_colons = options.delete(:ignore_colons) || false
         @domain ||= ""
       end
 
@@ -154,7 +155,8 @@ module Weary
       #
       # Returns the generated Resource.
       def resource(name, method, path="")
-        resource = Weary::Resource.new method, "#{domain}#{path}"
+        options = { :ignore_url_colons => @ignore_url_colons || false }
+        resource = Weary::Resource.new method, "#{domain}#{path}", options
         resource.optional *optional
         resource.required *required
         resource.defaults defaults

--- a/lib/weary/resource.rb
+++ b/lib/weary/resource.rb
@@ -11,8 +11,9 @@ module Weary
 
     attr_reader :method
 
-    def initialize(method, uri)
+    def initialize(method, uri, options={})
       @method = method
+      @ignore_url_colons = options.delete(:ignore_url_colons) || false
       self.url uri
     end
 
@@ -22,7 +23,10 @@ module Weary
     #
     # Returns an Addressable::Template
     def url(uri=nil)
-      @uri = Addressable::Template.new(uri.gsub(/:(\w+)/) { "{#{$1}}" }) unless uri.nil?
+      unless uri.nil?
+        uri.gsub!(/:(\w+)/) { "{#{$1}}" } unless @ignore_url_colons
+        @uri = Addressable::Template.new(uri)
+      end
       @uri
     end
 

--- a/spec/weary/client_spec.rb
+++ b/spec/weary/client_spec.rb
@@ -57,6 +57,19 @@ describe Weary::Client do
       resource = subject.get :show, "/show/{user}/{repo}"
       resource.url.expand(repo).to_s.should eql @url
     end
+
+    context "when :ignore_colons is given" do
+      before do
+        @url = "http://github.com:8000/api/v2/json/repos/show/mwunsch/weary"
+      end
+
+      it "should not create URL variables out of colons" do
+        repo = {:user => "mwunsch", :repo => "weary"}
+        subject.domain "http://github.com:8000/api/v2/json/repos", :ignore_colons => true
+        resource = subject.get :show, "/show/{user}/{repo}"
+        resource.url.expand(repo).to_s.should eql @url
+      end
+    end
   end
 
   describe "::optional" do


### PR DESCRIPTION
Added option to ignore URL colon variables so we can use port number in the domain. refs #6
