### PR TITLE
Approximately greater than operator does not work because its upper limi...

### DIFF
--- a/weary.gemspec
+++ b/weary.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "addressable", "~> 2.2.7"
   s.add_runtime_dependency "promise", "~> 0.3.0"
   s.add_runtime_dependency "simple_oauth", "~> 0.1.5"
-  s.add_runtime_dependency "multi_json", "~> 1.1.0"
+  s.add_runtime_dependency "multi_json", "> 1.1.0"
 end


### PR DESCRIPTION
...t is exclusive (http://docs.rubygems.org/read/chapter/16#page74). Curent version of multi_json, 1.2.0, is not being recognized by bundler as a valid version of this dependency rule. One way of solving it is to remove the approximate clause and just allow all versions greater than the 1.1.0, and that's what I did here.
