### PR TITLE
Added * for splat credentials parameters

### DIFF
--- a/lib/weary/middleware/basic_auth.rb
+++ b/lib/weary/middleware/basic_auth.rb
@@ -3,7 +3,7 @@ module Weary
     class BasicAuth
       AUTH_HEADER = "HTTP_AUTHORIZATION"
 
-      def initialize(app, credentials)
+      def initialize(app, *credentials)
         @app = app
         @auth = [credentials.join(':')].pack('m*')
       end


### PR DESCRIPTION
Added \* for splat credentials parameters for BasicAuth as logged on issue #13
