### PR TITLE
Update gem yard, yard-tomdoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,22 +12,18 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.2)
-    courtier (0.2.0)
-      finder
-      loaded
     crack (0.3.1)
     diff-lcs (1.1.3)
     excon (0.16.2)
     ffi (1.1.5)
-    finder (0.3.0)
-    loaded (0.0.1)
+    finder (0.4.0)
     mime-types (1.19)
     multi_json (1.3.6)
     promise (0.3.0)
     rack (1.4.1)
     rake (0.9.2.2)
-    rc (0.2.0)
-      courtier (= 0.2.0)
+    rc (0.4.0)
+      finder
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -37,14 +33,14 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.2)
     simple_oauth (0.1.9)
-    tomparse (0.2.1)
+    tomparse (0.4.0)
     typhoeus (0.4.2)
       ffi (~> 1.0)
       mime-types (~> 1.18)
     webmock (1.8.10)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
-    yard (0.8.2.1)
+    yard (0.8.4.1)
     yard-tomdoc (0.5.0)
       rc
       tomparse


### PR DESCRIPTION
loaded gem is no longer exist, so I can not complete bundle install.

```
$ bundle
Fetching gem metadata from http://rubygems.org/..
Could not find loaded-0.0.1 in any of the sources
```

Use command below:
$ bundle update yard yard-tomdoc
