### PR TITLE
Don't remove parameters with empty values.

### DIFF
--- a/lib/weary/resource.rb
+++ b/lib/weary/resource.rb
@@ -130,10 +130,8 @@ module Weary
       end
     end
 
-    # Private: For a set of parameters passed in to build a Request, delete
-    # those with no values, and merge them with the defaults.
+    # Private: Merge parameters passed in to build a Request with the defaults.
     def normalize_parameters(params)
-      params.delete_if {|k,v| v.nil? || v.to_s.empty? }
       params.update(defaults)
       params
     end

--- a/spec/weary/resource_spec.rb
+++ b/spec/weary/resource_spec.rb
@@ -247,6 +247,14 @@ describe Weary::Resource do
       req.params.should eql "user_id=markwunsch"
     end
 
+    it "passes nil value parameters into the request body" do
+      resource = described_class.new "GET", "http://api.twitter.com/version/users/show.json"
+      resource.required :user_id
+      resource.optional :include_entities
+      req = resource.request :user_id => "markwunsch", include_entities: nil
+      req.params.should eql "user_id=markwunsch&include_entities"
+    end
+
     it "passes nested hash parameters into the request body" do
       resource = described_class.new "GET", "http://github.com/api/v2/json/repos/show/mwunsch/weary"
       resource.optional :search


### PR DESCRIPTION
Sometimes things need to be set to nil or an empty string.

In our case we're using Weary to update a central user database. Somebody who loses a job for instance has to have their title and department changed to nil or an empty string. But these params were being removed.

I can't think of any reason empty params should be removed and all the tests passed without the code that removes them so it seems like there's no reason to have that functionality. 