### PR TITLE
Fix pass_values_onto_requestable to use method rather than the instance variable

### DIFF
--- a/lib/weary/requestable.rb
+++ b/lib/weary/requestable.rb
@@ -57,7 +57,7 @@ module Weary
     #
     # Returns the Requestable object.
     def pass_values_onto_requestable(requestable)
-      requestable.headers self.headers unless @headers.nil?
+      requestable.headers self.headers unless self.headers.nil? || self.headers.empty?
       requestable.adapter self.adapter unless @connection.nil?
       if has_middleware?
         @middlewares.each {|middleware| requestable.use *middleware }


### PR DESCRIPTION


Possible that I should have used something else in weary but in the end I did monkey patch `pass_values_onto_requestable`. What I wanted was the same headers over a small number of clients. So in my BaseClient I did add a method headers, hoping this to be passed on to all requests. I have to run some authentication first and the header is thus dynamic.

```ruby
BaseClient < Weary::Client
  cattr_accessor :headers
  def headers
    return @@headers ||= {}
  end
end
```
It didn't pass the values because in `pass_values_onto_requestable` it is first looking at the instance variable `@headers` and only after that it calls the headers method. Despite the shared name they can be very different things

```ruby
  def pass_values_onto_requestable(requestable)
      requestable.headers self.headers unless @headers.nil?
      requestable.adapter self.adapter unless @connection.nil?
  end
```

A simplified example to prove my point further:
```ruby
class A
  attr_accessor :b
  def initialize
    @b = "instance variable"
  end
  def b
    return "method"
  end
end

puts A.new.b # => method
puts A.new.instance_variable_get('@b') # => "instance variable"
```